### PR TITLE
Fix typo in template variable

### DIFF
--- a/templates/SelectUploadField.ss
+++ b/templates/SelectUploadField.ss
@@ -48,7 +48,7 @@
 								<span class="change">(change)</span>
 							</span>
 						</small>
-					<% else_if $canPreviewFolderx %>
+					<% else_if $canPreviewFolder %>
 						<small><% _t('UploadField.ADDTO', 'Add to') %> <strong>$DisplayFolderName</strong></small>
 					<% else_if $multiple %>
 						<small><% _t('UploadField.ATTACHFILES', 'Attach files') %></small>


### PR DESCRIPTION
Mistyped variable name. When $canSelectFolder was false, folder name couldn't be displayed.