### PR TITLE
MNT Update unit tests to phpunit 9 syntax.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "silverstripe/framework": "^4.0"
     },
     "require-dev": {
-        "sminnee/phpunit": "^5.7",
+        "phpunit/phpunit": "^9.5",
         "squizlabs/php_codesniffer": "^3.0"
     },
     "support": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,7 +1,9 @@
 <phpunit bootstrap="vendor/silverstripe/cms/tests/bootstrap.php" colors="true">
-    <testsuite name="selectupload">
-        <directory>tests/</directory>
-    </testsuite>
+    <testsuites>
+        <testsuite name="selectupload">
+            <directory>tests/</directory>
+        </testsuite>
+    </testsuites>
 
     <filter>
         <whitelist addUncoveredFilesFromWhitelist="true">

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # Select Upload Field
 
-[![Build Status](https://travis-ci.org/silverstripe/silverstripe-selectupload.svg?branch=master)](https://travis-ci.org/silverstripe/silverstripe-selectupload)
+[![Build Status](https://api.travis-ci.com/silverstripe/silverstripe-selectupload.svg?branch=2)](https://travis-ci.com/silverstripe/silverstripe-selectupload)
 [![SilverStripe supported module](https://img.shields.io/badge/silverstripe-supported-0071C4.svg)](https://www.silverstripe.org/software/addons/silverstripe-commercially-supported-module-list/)
 
 ## Introduction

--- a/tests/SelectUploadFieldTest.php
+++ b/tests/SelectUploadFieldTest.php
@@ -24,7 +24,7 @@ class SelectUploadFieldTest extends FunctionalTest
 
     protected $form;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -57,7 +57,7 @@ class SelectUploadFieldTest extends FunctionalTest
         $this->form = $controller->Form();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
 


### PR DESCRIPTION
Follows recommendations from https://docs.silverstripe.org/en/4/upgrading/phpunit9

## Parent Issue
- https://github.com/silverstripeltd/product-issues/issues/542