### PR TITLE
get_class() without args is deprecated with php83

### DIFF
--- a/src/FolderDropdownField.php
+++ b/src/FolderDropdownField.php
@@ -36,7 +36,7 @@ class FolderDropdownField extends TreeDropdownField
     {
         $request = Controller::curr()->getRequest();
         $session = $request->getSession();
-        $session->set(get_class() . '.FolderID', $folderID);
+        $session->set($this::class . '.FolderID', $folderID);
     }
 
     /**


### PR DESCRIPTION
https://www.php.net/releases/8.3/en.php